### PR TITLE
Update Server.h

### DIFF
--- a/src/etp/Server.h
+++ b/src/etp/Server.h
@@ -23,7 +23,7 @@ under the License.
 #include <stdexcept>
 #include <thread>
 #include <vector>
-
+#include <boost/asio/steady_timer.hpp>
 #include <boost/asio/bind_executor.hpp>
 #include <boost/asio/signal_set.hpp>
 #ifdef WITH_ETP_SSL


### PR DESCRIPTION
Resolved issue with missing header files in the build process. Followed guidance from @philippeVerney to include the missing header files and successfully built the project with the command 'cmake --build . --config Release -j2'. Verified that the project builds without errors.