### PR TITLE
Added Functionality for Writing Large 2D Data Arrays. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -388,3 +388,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+/build

--- a/src/etp/Server.h
+++ b/src/etp/Server.h
@@ -95,8 +95,8 @@ namespace ETP_NS
 			beast::string_view path)
 	{
 		if (base.empty())
-			return path.to_string();
-		std::string result = base.to_string();
+			return std::string(path.data());
+		std::string result = std::string(base.data());
 #ifdef BOOST_MSVC
 		char constexpr path_separator = '\\';
 		if (result.back() == path_separator)

--- a/src/etp/fesapi/FesapiHdfProxy.cpp
+++ b/src/etp/fesapi/FesapiHdfProxy.cpp
@@ -312,172 +312,61 @@ void FesapiHdfProxy::writeArrayNd(const std::string & groupName,
 		// Send Uninitialized Data Arrays
 		session_->sendAndBlock(puda, 0, 0x02);
 
-		// SEND MULTIPLE PUT DATA SUB ARRAYS MESSAGES
+		// SEND MULTIPLE PUT DATA SUBARRAYS MESSAGES
+		std::cout << "Writing Subarrays: This may take some time." << std::endl;
+		std::cout << "Please wait..." << std::endl;
+
+		// Initial Starts and Counts
+		std::vector<int64_t> starts{};
+		std::vector<int64_t> counts{};
+
+		for (size_t i = 0; i < numDimensions; ++i) {
+			starts.push_back(0);
+			counts.push_back(numValuesInEachDimension[i]);
+		}
+
+		// Recursively Write Subarrays
 		if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::DOUBLE) {
-			if (numDimensions == 2)
-			{
-				// Create PutDataSubarray message
-				std::vector<int64_t> starts{};
-				std::vector<int64_t> counts{};
-
-				for (size_t i = 0; i < numDimensions; ++i) 
-				{
-					starts.push_back(0);
-					counts.push_back(numValuesInEachDimension[i]);
-				}
-
-				std::cout << "Writing Sub Arrays: This may take some time." << std::endl;
-				std::cout << "Please wait..." << std::endl;
-				
-				writeSubArray2d<double>(
-					uri, pathInResource, numValuesInEachDimension[1],
-					starts,
-					counts,
-					values);
-			}
-			else
-			{
-				throw logic_error("Subarrays are implemented for 2D double data arrays only.");
-			}
+			writeSubArrayNd<double>(uri, pathInResource, counts,
+				starts,
+				counts,
+				values);
 		}
 		else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::FLOAT) {
-			if (numDimensions == 2)
-			{
-				// Create PutDataSubarray message
-				std::vector<int64_t> starts{};
-				std::vector<int64_t> counts{};
-
-				for (size_t i = 0; i < numDimensions; ++i)
-				{
-					starts.push_back(0);
-					counts.push_back(numValuesInEachDimension[i]);
-				}
-
-				std::cout << "Writing Sub Arrays: This may take some time." << std::endl;
-				std::cout << "Please wait..." << std::endl;
-
-				writeSubArray2d<float>(
-					uri, pathInResource, numValuesInEachDimension[1],
-					starts,
-					counts,
-					values);
-			}
-			else
-			{
-				throw logic_error("Subarrays are implemented for 2D float data arrays only.");
-			}
+			writeSubArrayNd<float>(uri, pathInResource, counts,
+				starts,
+				counts,
+				values);
 		}
 		else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT64 || 
 			datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::UINT64) {
-				if (numDimensions == 2)
-				{
-					// Create PutDataSubarray message
-					std::vector<int64_t> starts{};
-					std::vector<int64_t> counts{};
-
-					for (size_t i = 0; i < numDimensions; ++i)
-					{
-						starts.push_back(0);
-						counts.push_back(numValuesInEachDimension[i]);
-					}
-
-					std::cout << "Writing Sub Arrays: This may take some time." << std::endl;
-					std::cout << "Please wait..." << std::endl;
-
-					writeSubArray2d<int64_t>(
-						uri, pathInResource, numValuesInEachDimension[1],
-						starts,
-						counts,
-						values);
-				}
-				else
-				{
-					throw logic_error("Subarrays are implemented for 2D int64 data arrays only.");
-				}
+			writeSubArrayNd<int64_t>(uri, pathInResource, counts,
+				starts,
+				counts,
+				values);
 		}
 		else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT32 || 
 			datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::UINT32) {
-				if (numDimensions == 2)
-				{
-					// Create PutDataSubarray message
-					std::vector<int64_t> starts{};
-					std::vector<int64_t> counts{};
-
-					for (size_t i = 0; i < numDimensions; ++i)
-					{
-						starts.push_back(0);
-						counts.push_back(numValuesInEachDimension[i]);
-					}
-
-					std::cout << "Writing Sub Arrays: This may take some time." << std::endl;
-					std::cout << "Please wait..." << std::endl;
-
-					writeSubArray2d<int32_t>(
-						uri, pathInResource, numValuesInEachDimension[1],
-						starts,
-						counts,
-						values);
-				}
-				else
-				{
-					throw logic_error("Subarrays are implemented for 2D int32 data arrays only.");
-				}
+			writeSubArrayNd<int32_t>(uri, pathInResource, counts,
+				starts,
+				counts,
+				values);
 		}
 		else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT16 || 
 			datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::UINT16) {
-				if (numDimensions == 2)
-				{
-					// Create PutDataSubarray message
-					std::vector<int64_t> starts{};
-					std::vector<int64_t> counts{};
-
-					for (size_t i = 0; i < numDimensions; ++i)
-					{
-						starts.push_back(0);
-						counts.push_back(numValuesInEachDimension[i]);
-					}
-
-					std::cout << "Writing Sub Arrays: This may take some time." << std::endl;
-					std::cout << "Please wait..." << std::endl;
-
-					writeSubArray2d<short>(
-						uri, pathInResource, numValuesInEachDimension[1],
-						starts,
-						counts,
-						values);
-				}
-				else
-				{
-					throw logic_error("Subarrays are implemented for 2D short data arrays only.");
-				}
+			writeSubArrayNd<short>(
+				uri, pathInResource, counts,
+				starts,
+				counts,
+				values);
 		}
 		else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT8 || 
 			datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::UINT8) {
-				if (numDimensions == 2)
-				{
-					// Create PutDataSubarray message
-					std::vector<int64_t> starts{};
-					std::vector<int64_t> counts{};
-
-					for (size_t i = 0; i < numDimensions; ++i)
-					{
-						starts.push_back(0);
-						counts.push_back(numValuesInEachDimension[i]);
-					}
-
-					std::cout << "Writing Sub Arrays: This may take some time." << std::endl;
-					std::cout << "Please wait..." << std::endl;
-
-					writeSubArray2d<char>(
-						uri, pathInResource, numValuesInEachDimension[1],
-						starts,
-						counts,
-						values);
-				}
-				else
-				{
-					throw logic_error("Subarrays are implemented for 2D byte data arrays only.");
-				}
+			writeSubArrayNd<char>(
+				uri, pathInResource, counts,
+				starts,
+				counts,
+				values);
 		}
 		else {
 			throw logic_error(

--- a/src/etp/fesapi/FesapiHdfProxy.cpp
+++ b/src/etp/fesapi/FesapiHdfProxy.cpp
@@ -122,63 +122,368 @@ void FesapiHdfProxy::writeArrayNd(const std::string & groupName,
 	const uint64_t * numValuesInEachDimension,
 	unsigned int numDimensions)
 {
-	if (!isOpened()) {
+	if (!isOpened())
 		open();
-	}
 
-	Energistics::Etp::v12::Protocol::DataArray::PutDataArrays pda;
-	pda.dataArrays["0"].uid.uri = buildEtp12Uri();
-	pda.dataArrays["0"].uid.pathInResource = (groupName.back() == '/' ? groupName : groupName + '/') + name;
+	// URI AND PATH
+	std::string uri{ buildEtp12Uri() };
 
-	size_t totalCount = 1;
-	std::vector<int64_t> dimensions;
-	for (size_t i = 0; i < numDimensions; ++i) {
+	std::string pathInResource{ (groupName.back() == '/' ? 
+		groupName : groupName + '/') + name };
+
+	// Create Dimensions and Total Count
+	size_t totalCount{ 1 };
+	std::vector<int64_t> dimensions{};
+
+	for (size_t i = 0; i < numDimensions; ++i)
+	{
 		dimensions.push_back(numValuesInEachDimension[i]);
 		totalCount *= numValuesInEachDimension[i];
 	}
-	pda.dataArrays["0"].array.dimensions = dimensions;
 
-	Energistics::Etp::v12::Datatypes::AnyArray data;
-	if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::DOUBLE) {
-		Energistics::Etp::v12::Datatypes::ArrayOfDouble avroArray;
-		avroArray.values = std::vector<double>(static_cast<const double*>(values), static_cast<const double*>(values) + totalCount);
-		data.item.set_ArrayOfDouble(avroArray);
-	}
-	else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::FLOAT) {
-		Energistics::Etp::v12::Datatypes::ArrayOfFloat avroArray;
-		avroArray.values = std::vector<float>(static_cast<const float*>(values), static_cast<const float*>(values) + totalCount);
-		data.item.set_ArrayOfFloat(avroArray);
-	}
-	else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT64 || datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT64) {
-		Energistics::Etp::v12::Datatypes::ArrayOfLong avroArray;
-		avroArray.values = std::vector<int64_t>(static_cast<const int64_t*>(values), static_cast<const int64_t*>(values) + totalCount);
-		data.item.set_ArrayOfLong(avroArray);
-	}
-	else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT32 || datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::UINT32) {
-		Energistics::Etp::v12::Datatypes::ArrayOfInt avroArray;
-		avroArray.values = std::vector<int32_t>(static_cast<const int32_t*>(values), static_cast<const int32_t*>(values) + totalCount);
-		data.item.set_ArrayOfInt(avroArray);
-	}
-	else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT16 || datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::UINT16) {
-		Energistics::Etp::v12::Datatypes::ArrayOfInt avroArray;
-		for (size_t i = 0; i < totalCount; ++i) {
-			avroArray.values.push_back(static_cast<const short*>(values)[i]);
-		}
-		data.item.set_ArrayOfInt(avroArray);
-	}
-	else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT8 || datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::UINT8) {
-		std::string avroArray;
-		for (size_t i = 0; i < totalCount; ++i) {
-			avroArray.push_back(static_cast<const char*>(values)[i]);
-		}
-		data.item.set_bytes(avroArray);
-	}
-	else {
-		throw logic_error("You need to give a COMMON_NS::AbstractObject::numericalDatatypeEnum as the datatype");
-	}
-	pda.dataArrays["0"].array.data = data;
+	// Determine Value Size (bytes)
+	int valueSize{ 1 };
 
-	session_->send(pda, 0, 0x02);
+	if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::DOUBLE)
+	{
+		valueSize = sizeof(double);
+	}
+	else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::FLOAT)
+	{
+		valueSize = sizeof(float);
+	}
+	else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT64 ||
+		datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT64)
+	{
+		valueSize = sizeof(int64_t);
+	}
+	else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT32 ||
+		datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::UINT32)
+	{
+		valueSize = sizeof(int32_t);
+	}
+	else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT16 ||
+		datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::UINT16)
+	{
+		valueSize = sizeof(short);
+	}
+	else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT8 ||
+		datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::UINT8)
+	{
+		valueSize = sizeof(char);
+	}
+	else
+	{
+		throw logic_error(
+			"You need to give a COMMON_NS::AbstractObject::numericalDatatypeEnum as the datatype");
+	}
+
+	if (totalCount * valueSize <= maxArraySize_)
+	{
+		// PUT DATA ARRAYS
+		Energistics::Etp::v12::Protocol::DataArray::PutDataArrays pda{};
+		pda.dataArrays["0"].uid.uri = uri;
+		pda.dataArrays["0"].uid.pathInResource = pathInResource;
+		pda.dataArrays["0"].array.dimensions = dimensions;
+
+		// Create AVRO Array
+		Energistics::Etp::v12::Datatypes::AnyArray data;
+		if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::DOUBLE) 
+		{
+			Energistics::Etp::v12::Datatypes::ArrayOfDouble avroArray;
+
+			avroArray.values = std::vector<double>(
+				static_cast<const double*>(values), 
+				static_cast<const double*>(values) + totalCount);
+
+			data.item.set_ArrayOfDouble(avroArray);
+		}
+		else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::FLOAT) 
+		{
+			Energistics::Etp::v12::Datatypes::ArrayOfFloat avroArray;
+
+			avroArray.values = std::vector<float>(
+				static_cast<const float*>(values), 
+				static_cast<const float*>(values) + totalCount);
+
+			data.item.set_ArrayOfFloat(avroArray);
+		}
+		else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT64 || 
+			datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::UINT64) {
+			Energistics::Etp::v12::Datatypes::ArrayOfLong avroArray;
+
+			avroArray.values = std::vector<int64_t>(
+				static_cast<const int64_t*>(values), 
+				static_cast<const int64_t*>(values) + totalCount);
+
+			data.item.set_ArrayOfLong(avroArray);
+		}
+		else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT32 || 
+			datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::UINT32) {
+			Energistics::Etp::v12::Datatypes::ArrayOfInt avroArray;
+
+			avroArray.values = std::vector<int32_t>(
+				static_cast<const int32_t*>(values), 
+				static_cast<const int32_t*>(values) + totalCount);
+
+			data.item.set_ArrayOfInt(avroArray);
+		}
+		else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT16 || 
+			datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::UINT16) {
+			Energistics::Etp::v12::Datatypes::ArrayOfInt avroArray;
+
+			for (size_t i = 0; i < totalCount; ++i) 
+			{
+				avroArray.values.push_back(static_cast<const short*>(values)[i]);
+			}
+
+			data.item.set_ArrayOfInt(avroArray);
+		}
+		else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT8 || 
+			datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::UINT8) {
+			std::string avroArray;
+
+			for (size_t i = 0; i < totalCount; ++i)
+			{
+				avroArray.push_back(static_cast<const char*>(values)[i]);
+			}
+
+			data.item.set_bytes(avroArray);
+		}
+		else {
+			throw logic_error(
+				"You need to give a COMMON_NS::AbstractObject::numericalDatatypeEnum as the datatype");
+		}
+
+		pda.dataArrays["0"].array.data = data;
+
+		// Send Data Arrays
+		session_->send(pda, 0, 0x02);
+	}
+	else 
+	{
+		// PUT UNINITIALIZED DATA ARRAYS
+		Energistics::Etp::v12::Protocol::DataArray::PutUninitializedDataArrays puda;
+		puda.dataArrays["0"].uid.uri = uri;
+		puda.dataArrays["0"].uid.pathInResource = pathInResource;
+		puda.dataArrays["0"].metadata.dimensions = dimensions;
+
+		// Assign Data Type
+		if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::DOUBLE)
+		{
+			puda.dataArrays["0"].metadata.transportArrayType =
+				Energistics::Etp::v12::Datatypes::AnyArrayType::arrayOfDouble;
+		}
+		else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::FLOAT)
+		{
+			puda.dataArrays["0"].metadata.transportArrayType =
+				Energistics::Etp::v12::Datatypes::AnyArrayType::arrayOfFloat;
+		}
+		else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT64 ||
+			datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT64)
+		{
+			puda.dataArrays["0"].metadata.transportArrayType =
+				Energistics::Etp::v12::Datatypes::AnyArrayType::arrayOfLong;
+		}
+		else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT32 ||
+			datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::UINT32)
+		{
+			puda.dataArrays["0"].metadata.transportArrayType =
+				Energistics::Etp::v12::Datatypes::AnyArrayType::arrayOfInt;
+		}
+		else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT16 ||
+			datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::UINT16)
+		{
+			puda.dataArrays["0"].metadata.transportArrayType =
+				Energistics::Etp::v12::Datatypes::AnyArrayType::arrayOfInt;
+		}
+		else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT8 ||
+			datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::UINT8)
+		{
+			puda.dataArrays["0"].metadata.transportArrayType =
+				Energistics::Etp::v12::Datatypes::AnyArrayType::bytes;
+		}
+		else
+		{
+			throw logic_error(
+				"You need to give a COMMON_NS::AbstractObject::numericalDatatypeEnum as the datatype");
+		}
+
+		// Send Uninitialized Data Arrays
+		session_->sendAndBlock(puda, 0, 0x02);
+
+		// SEND MULTIPLE PUT DATA SUB ARRAYS MESSAGES
+		if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::DOUBLE) {
+			if (numDimensions == 2)
+			{
+				// Create PutDataSubarray message
+				std::vector<int64_t> starts{};
+				std::vector<int64_t> counts{};
+
+				for (size_t i = 0; i < numDimensions; ++i) 
+				{
+					starts.push_back(0);
+					counts.push_back(numValuesInEachDimension[i]);
+				}
+
+				std::cout << "Writing Sub Arrays: This may take some time." << std::endl;
+				std::cout << "Please wait..." << std::endl;
+				
+				writeSubArray2d<double>(
+					uri, pathInResource, numValuesInEachDimension[1],
+					starts,
+					counts,
+					values);
+			}
+			else
+			{
+				throw logic_error("Subarrays are implemented for 2D double data arrays only.");
+			}
+		}
+		else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::FLOAT) {
+			if (numDimensions == 2)
+			{
+				// Create PutDataSubarray message
+				std::vector<int64_t> starts{};
+				std::vector<int64_t> counts{};
+
+				for (size_t i = 0; i < numDimensions; ++i)
+				{
+					starts.push_back(0);
+					counts.push_back(numValuesInEachDimension[i]);
+				}
+
+				std::cout << "Writing Sub Arrays: This may take some time." << std::endl;
+				std::cout << "Please wait..." << std::endl;
+
+				writeSubArray2d<float>(
+					uri, pathInResource, numValuesInEachDimension[1],
+					starts,
+					counts,
+					values);
+			}
+			else
+			{
+				throw logic_error("Subarrays are implemented for 2D float data arrays only.");
+			}
+		}
+		else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT64 || 
+			datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::UINT64) {
+				if (numDimensions == 2)
+				{
+					// Create PutDataSubarray message
+					std::vector<int64_t> starts{};
+					std::vector<int64_t> counts{};
+
+					for (size_t i = 0; i < numDimensions; ++i)
+					{
+						starts.push_back(0);
+						counts.push_back(numValuesInEachDimension[i]);
+					}
+
+					std::cout << "Writing Sub Arrays: This may take some time." << std::endl;
+					std::cout << "Please wait..." << std::endl;
+
+					writeSubArray2d<int64_t>(
+						uri, pathInResource, numValuesInEachDimension[1],
+						starts,
+						counts,
+						values);
+				}
+				else
+				{
+					throw logic_error("Subarrays are implemented for 2D int64 data arrays only.");
+				}
+		}
+		else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT32 || 
+			datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::UINT32) {
+				if (numDimensions == 2)
+				{
+					// Create PutDataSubarray message
+					std::vector<int64_t> starts{};
+					std::vector<int64_t> counts{};
+
+					for (size_t i = 0; i < numDimensions; ++i)
+					{
+						starts.push_back(0);
+						counts.push_back(numValuesInEachDimension[i]);
+					}
+
+					std::cout << "Writing Sub Arrays: This may take some time." << std::endl;
+					std::cout << "Please wait..." << std::endl;
+
+					writeSubArray2d<int32_t>(
+						uri, pathInResource, numValuesInEachDimension[1],
+						starts,
+						counts,
+						values);
+				}
+				else
+				{
+					throw logic_error("Subarrays are implemented for 2D int32 data arrays only.");
+				}
+		}
+		else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT16 || 
+			datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::UINT16) {
+				if (numDimensions == 2)
+				{
+					// Create PutDataSubarray message
+					std::vector<int64_t> starts{};
+					std::vector<int64_t> counts{};
+
+					for (size_t i = 0; i < numDimensions; ++i)
+					{
+						starts.push_back(0);
+						counts.push_back(numValuesInEachDimension[i]);
+					}
+
+					std::cout << "Writing Sub Arrays: This may take some time." << std::endl;
+					std::cout << "Please wait..." << std::endl;
+
+					writeSubArray2d<short>(
+						uri, pathInResource, numValuesInEachDimension[1],
+						starts,
+						counts,
+						values);
+				}
+				else
+				{
+					throw logic_error("Subarrays are implemented for 2D short data arrays only.");
+				}
+		}
+		else if (datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::INT8 || 
+			datatype == COMMON_NS::AbstractObject::numericalDatatypeEnum::UINT8) {
+				if (numDimensions == 2)
+				{
+					// Create PutDataSubarray message
+					std::vector<int64_t> starts{};
+					std::vector<int64_t> counts{};
+
+					for (size_t i = 0; i < numDimensions; ++i)
+					{
+						starts.push_back(0);
+						counts.push_back(numValuesInEachDimension[i]);
+					}
+
+					std::cout << "Writing Sub Arrays: This may take some time." << std::endl;
+					std::cout << "Please wait..." << std::endl;
+
+					writeSubArray2d<char>(
+						uri, pathInResource, numValuesInEachDimension[1],
+						starts,
+						counts,
+						values);
+				}
+				else
+				{
+					throw logic_error("Subarrays are implemented for 2D byte data arrays only.");
+				}
+		}
+		else {
+			throw logic_error(
+				"You need to give a COMMON_NS::AbstractObject::numericalDatatypeEnum as the datatype");
+		}
+	}
 }
 
 void FesapiHdfProxy::createArrayNd(


### PR DESCRIPTION
Modified FesapiHDFProxy class to accommodate transmission of larger 2D data arrays in multiple putDataSubrrays messages. Also fixed beast::string_view issue in server.h (to_string() is unrecognizable, maybe because I am using Boost v1.81).

**CHANGES:**

1. Array size is calculated first. 
2. If it is smaller than the threshold value “FesapiHDFProxy::maxArraySize_”, which is set to 4 MB (This can be altered), the data array is sent in a single putDataArray message, just like it was sent before in FesapiHDFProxy::writeArrayNd(). 
3. If array size is greater than the threshold value:

- > First, a single putUnintializedDataArray message is sent in which uri, pathInResource, datatype, and the dimensions of the data array are populated. putUninitializedDataArraysResponse is not handled.
- > Then the array is sent in multiple putDataSubarrays messages using “Divide-and-Conquer” paradigm. A template method FesapiHDFProxy::writeSubArray2d() that takes reference to original row-major data array, and keeps on dividing it into halves recursively. This is done by managing “starts” and “counts” vectors that are required for putDataSubarrays messages. The subarray is immediately sent if its size equals or is smaller than the threshold value. putDataSubarraysResponse are not handled.

4. The template function works for 2D data arrays only for the following primitive types: double, float, int64, int32, short, and byte.

**NOTE:** The threshold value “maxArraySize_” needs to be readjusted. I think, it should be somewhat smaller than maxWebSocketMessagePayloadSize because it counts the compressed size of the array and AVRO Header size. I have randomly picked 4 MB, because I was able to successfully write 4 MB data array with a single putDataArrays message.
